### PR TITLE
Introduce a LoggingT transformer for logging throughout the program

### DIFF
--- a/file-fun.cabal
+++ b/file-fun.cabal
@@ -20,6 +20,10 @@ executable file-fun
   build-depends:       base
                      , optparse-applicative
                      , mtl
+                     , monad-logger
+                     , fast-logger
+                     , text
+                     , time
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
This introduces a LoggingT monad transformer to App, allowing for
various logs to be generated throughout. Logging functionality
($logDebug, $logInfo) comes from Control.Monad.Logger, 
leveraging Template Haskell.

This also introduces an optional verbosity flag to the CLI; by default,
logging is disabled, but allows for developers to opt-in.
